### PR TITLE
feat: handle unstyled darkmode on Android

### DIFF
--- a/.changeset/shaggy-fishes-kick.md
+++ b/.changeset/shaggy-fishes-kick.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+feat: handle automatic darkmode changes on Android


### PR DESCRIPTION
## PR Description

This PR handles unstyled dark mode on Android, and should fix #227 

Now when user doesn't change anything related to styling the tabs will adapt to the default styling (especially useful for Material You)

## How to test?

Change dark mode

## Screenshots


https://github.com/user-attachments/assets/cb8a7427-4b07-46f9-9d96-ff0796c3a5cd

