### PR TITLE
fix(iOS): janky tab switch between colored and uncolored tabs

### DIFF
--- a/.changeset/stable-tab-tint.md
+++ b/.changeset/stable-tab-tint.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+Keep iOS tab transitions smooth when switching between tabs with and without active tint colors.

--- a/apps/example/ios/Podfile.lock
+++ b/apps/example/ios/Podfile.lock
@@ -2842,7 +2842,7 @@ SPEC CHECKSUMS:
   React-logger: a3cb5b29c32b8e447b5a96919340e89334062b48
   React-Mapbuffer: 9d2434a42701d6144ca18f0ca1c4507808ca7696
   React-microtasksnativemodule: 75b6604b667d297292345302cc5bfb6b6aeccc1b
-  react-native-bottom-tabs: 5b7b8ee99ea2f19a496cabe8f6ec322b4d86c28d
+  react-native-bottom-tabs: df48704fe0d3f7566ab63e2b77b47e40f74a9051
   react-native-safe-area-context: c6e2edd1c1da07bdce287fa9d9e60c5f7b514616
   React-NativeModulesApple: 879fbdc5dcff7136abceb7880fe8a2022a1bd7c3
   React-oscompat: 93b5535ea7f7dff46aaee4f78309a70979bdde9d

--- a/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
@@ -267,15 +267,12 @@ extension View {
 
   @ViewBuilder
   func tintColor(_ color: PlatformColor?) -> some View {
-    if let color {
-      let color = Color(color)
-      if #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
-        self.tint(color)
-      } else {
-        self.accentColor(color)
-      }
+    let color = color.map(Color.init)
+
+    if #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
+      self.tint(color)
     } else {
-      self
+      self.accentColor(color)
     }
   }
 


### PR DESCRIPTION
<!-- Please provide information about your pull request. -->

## PR Description

<!-- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) -->

When switching between a tint-colored tab and a standard tab, the native component was remounting and causing the tab switch to cut mid-animation, feeling janky.

This fix makes it so the Tab keeps mounted and switch stays smooth.
