### PR TITLE
fix(TabView): respect user-supplied tabBarHidden

### DIFF
--- a/.changeset/respect-user-tab-bar-hidden.md
+++ b/.changeset/respect-user-tab-bar-hidden.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+Respect user-supplied `tabBarHidden` on `TabView`. The prop was wired natively but the JS wrapper hardcoded `tabBarHidden={!!renderCustomTabBar}` after the `{...props}` spread, so any user value was silently overwritten. The prop is now declared on the public `TabView` API and only falls back to the custom-tab-bar default when the caller omits it, which lets iOS 26+ users hide the SwiftUI-backed tab bar from JS again.

--- a/.changeset/respect-user-tab-bar-hidden.md
+++ b/.changeset/respect-user-tab-bar-hidden.md
@@ -2,4 +2,4 @@
 'react-native-bottom-tabs': patch
 ---
 
-Respect user-supplied `tabBarHidden` on `TabView`. The prop was wired natively but the JS wrapper hardcoded `tabBarHidden={!!renderCustomTabBar}` after the `{...props}` spread, so any user value was silently overwritten. The prop is now declared on the public `TabView` API and only falls back to the custom-tab-bar default when the caller omits it, which lets iOS 26+ users hide the SwiftUI-backed tab bar from JS again.
+Respect user-supplied `tabBarHidden` on `TabView`.

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -39,6 +39,7 @@ import NativeBottomTabsScreenLayout from './Examples/NativeBottomTabsScreenLayou
 import NativeBottomTabsLazy from './Examples/NativeBottomTabsLazy';
 import BottomAccessoryView from './Examples/BottomAccessoryView';
 import TabBarHidden from './Examples/TabBarHidden';
+import CustomTabBar from './Examples/CustomTabBar';
 import NativeBottomTabsTabBarHidden from './Examples/NativeBottomTabsTabBarHidden';
 import { useLogger } from '@react-navigation/devtools';
 import LazyTabs from './Examples/LazyTabs';
@@ -110,6 +111,10 @@ const examples = [
     name: 'Tab Bar Hidden',
   },
   {
+    component: CustomTabBar,
+    name: 'Custom tabBar',
+  },
+  {
     component: FourTabsRippleColor,
     name: 'Four Tabs with ripple Color',
     platform: 'android',
@@ -163,7 +168,7 @@ const examples = [
   },
   {
     component: NativeBottomTabsCustomTabBar,
-    name: 'Native Bottom Tabs with Custom Tab Bar',
+    name: 'Native Bottom Tabs with custom tabBar',
   },
   {
     component: NativeBottomTabsScreenLayout,

--- a/apps/example/src/App.tsx
+++ b/apps/example/src/App.tsx
@@ -38,6 +38,8 @@ import NativeBottomTabsFreezeOnBlur from './Examples/NativeBottomTabsFreezeOnBlu
 import NativeBottomTabsScreenLayout from './Examples/NativeBottomTabsScreenLayout';
 import NativeBottomTabsLazy from './Examples/NativeBottomTabsLazy';
 import BottomAccessoryView from './Examples/BottomAccessoryView';
+import TabBarHidden from './Examples/TabBarHidden';
+import NativeBottomTabsTabBarHidden from './Examples/NativeBottomTabsTabBarHidden';
 import { useLogger } from '@react-navigation/devtools';
 import LazyTabs from './Examples/LazyTabs';
 import { LogBox } from 'react-native';
@@ -104,6 +106,10 @@ const examples = [
   },
   { component: LazyTabs, name: 'Lazy Tabs' },
   {
+    component: TabBarHidden,
+    name: 'Tab Bar Hidden',
+  },
+  {
     component: FourTabsRippleColor,
     name: 'Four Tabs with ripple Color',
     platform: 'android',
@@ -166,6 +172,10 @@ const examples = [
   {
     component: NativeBottomTabsLazy,
     name: 'Native Bottom Tabs with Lazy',
+  },
+  {
+    component: NativeBottomTabsTabBarHidden,
+    name: 'Native Bottom Tabs with tabBarHidden',
   },
   { component: NativeBottomTabs, name: 'Native Bottom Tabs' },
   { component: JSBottomTabs, name: 'JS Bottom Tabs' },

--- a/apps/example/src/Examples/CustomTabBar.tsx
+++ b/apps/example/src/Examples/CustomTabBar.tsx
@@ -1,0 +1,104 @@
+import TabView from 'react-native-bottom-tabs';
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+const routes = [
+  {
+    key: 'article',
+    title: 'Article',
+    focusedIcon: require('../../assets/icons/article_dark.png'),
+  },
+  {
+    key: 'albums',
+    title: 'Albums',
+    focusedIcon: require('../../assets/icons/grid_dark.png'),
+  },
+  {
+    key: 'contacts',
+    title: 'Contacts',
+    focusedIcon: require('../../assets/icons/person_dark.png'),
+  },
+];
+
+export default function CustomTabBar() {
+  const [index, setIndex] = useState(0);
+
+  return (
+    <TabView
+      sidebarAdaptable
+      navigationState={{ index, routes }}
+      onIndexChange={setIndex}
+      renderScene={({ route }) => (
+        <View style={styles.screen}>
+          <Text style={styles.title}>{route.title}</Text>
+        </View>
+      )}
+      tabBar={() => (
+        <View style={styles.customTabBar}>
+          {routes.map((route, routeIndex) => {
+            const focused = routeIndex === index;
+
+            return (
+              <Pressable
+                key={route.key}
+                style={[
+                  styles.customTabBarItem,
+                  focused && styles.customTabBarItemFocused,
+                ]}
+                onPress={() => setIndex(routeIndex)}
+              >
+                <Text
+                  style={[
+                    styles.customTabBarLabel,
+                    focused && styles.customTabBarLabelFocused,
+                  ]}
+                >
+                  {route.title}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '600',
+  },
+  customTabBar: {
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 12,
+    paddingTop: 10,
+    paddingBottom: 18,
+    backgroundColor: '#24292f',
+  },
+  customTabBarItem: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 44,
+    borderRadius: 6,
+    backgroundColor: '#3b434c',
+  },
+  customTabBarItemFocused: {
+    backgroundColor: '#ffffff',
+  },
+  customTabBarLabel: {
+    color: '#ffffff',
+    fontWeight: '600',
+  },
+  customTabBarLabelFocused: {
+    color: '#24292f',
+  },
+});

--- a/apps/example/src/Examples/NativeBottomTabsTabBarHidden.tsx
+++ b/apps/example/src/Examples/NativeBottomTabsTabBarHidden.tsx
@@ -1,0 +1,93 @@
+import { createNativeBottomTabNavigator } from '@bottom-tabs/react-navigation';
+import { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+
+const Tab = createNativeBottomTabNavigator();
+
+type TabBarHiddenScreenProps = {
+  title: string;
+  tabBarHidden: boolean;
+  onToggleTabBarHidden: () => void;
+};
+
+function TabBarHiddenScreen({
+  title,
+  tabBarHidden,
+  onToggleTabBarHidden,
+}: TabBarHiddenScreenProps) {
+  return (
+    <View style={styles.screen}>
+      <Text style={styles.title}>{title}</Text>
+      <Button
+        title={`${tabBarHidden ? 'Show' : 'Hide'} Tab Bar`}
+        onPress={onToggleTabBarHidden}
+      />
+    </View>
+  );
+}
+
+export default function NativeBottomTabsTabBarHidden() {
+  const [tabBarHidden, setTabBarHidden] = useState(false);
+  const toggleTabBarHidden = () => setTabBarHidden((value) => !value);
+
+  return (
+    <Tab.Navigator sidebarAdaptable tabBarHidden={tabBarHidden}>
+      <Tab.Screen
+        name="Article"
+        options={{
+          tabBarIcon: () => require('../../assets/icons/article_dark.png'),
+        }}
+      >
+        {() => (
+          <TabBarHiddenScreen
+            title="Article"
+            tabBarHidden={tabBarHidden}
+            onToggleTabBarHidden={toggleTabBarHidden}
+          />
+        )}
+      </Tab.Screen>
+      <Tab.Screen
+        name="Albums"
+        options={{
+          tabBarIcon: () => require('../../assets/icons/grid_dark.png'),
+        }}
+      >
+        {() => (
+          <TabBarHiddenScreen
+            title="Albums"
+            tabBarHidden={tabBarHidden}
+            onToggleTabBarHidden={toggleTabBarHidden}
+          />
+        )}
+      </Tab.Screen>
+      <Tab.Screen
+        name="Contacts"
+        options={{
+          tabBarIcon: () => require('../../assets/icons/person_dark.png'),
+        }}
+      >
+        {() => (
+          <TabBarHiddenScreen
+            title="Contacts"
+            tabBarHidden={tabBarHidden}
+            onToggleTabBarHidden={toggleTabBarHidden}
+          />
+        )}
+      </Tab.Screen>
+    </Tab.Navigator>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+    padding: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '600',
+  },
+});

--- a/apps/example/src/Examples/TabBarHidden.tsx
+++ b/apps/example/src/Examples/TabBarHidden.tsx
@@ -1,0 +1,81 @@
+import TabView from 'react-native-bottom-tabs';
+import { useState } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+
+const routes = [
+  {
+    key: 'article',
+    title: 'Article',
+    focusedIcon: require('../../assets/icons/article_dark.png'),
+  },
+  {
+    key: 'albums',
+    title: 'Albums',
+    focusedIcon: require('../../assets/icons/grid_dark.png'),
+  },
+  {
+    key: 'contacts',
+    title: 'Contacts',
+    focusedIcon: require('../../assets/icons/person_dark.png'),
+  },
+];
+
+type TabBarHiddenScreenProps = {
+  title: string;
+  tabBarHidden: boolean;
+  onToggleTabBarHidden: () => void;
+};
+
+function TabBarHiddenScreen({
+  title,
+  tabBarHidden,
+  onToggleTabBarHidden,
+}: TabBarHiddenScreenProps) {
+  return (
+    <View style={styles.screen}>
+      <Text style={styles.title}>{title}</Text>
+      <Button
+        title={`${tabBarHidden ? 'Show' : 'Hide'} Tab Bar`}
+        onPress={onToggleTabBarHidden}
+      />
+    </View>
+  );
+}
+
+export default function TabBarHidden() {
+  const [index, setIndex] = useState(0);
+  const [tabBarHidden, setTabBarHidden] = useState(false);
+
+  return (
+    <TabView
+      sidebarAdaptable
+      navigationState={{ index, routes }}
+      onIndexChange={setIndex}
+      renderScene={({ route }) => (
+        <TabBarHiddenScreen
+          title={route.title}
+          tabBarHidden={tabBarHidden}
+          onToggleTabBarHidden={() => setTabBarHidden((value) => !value)}
+        />
+      )}
+      tabBarHidden={tabBarHidden}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+    padding: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '600',
+  },
+  status: {
+    fontSize: 16,
+  },
+});

--- a/apps/example/src/Examples/TabBarHidden.tsx
+++ b/apps/example/src/Examples/TabBarHidden.tsx
@@ -75,7 +75,4 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: '600',
   },
-  status: {
-    fontSize: 16,
-  },
 });

--- a/packages/react-native-bottom-tabs/src/TabView.tsx
+++ b/packages/react-native-bottom-tabs/src/TabView.tsx
@@ -212,6 +212,14 @@ interface Props<Route extends BaseRoute> {
    * @default 'locale'
    */
   layoutDirection?: LayoutDirection;
+  /**
+   * Whether to hide the native tab bar. Defaults to `true` when a custom
+   * `tabBar` is provided (so the native bar does not stack on top of the
+   * custom one), otherwise `false`. Set explicitly to override the default,
+   * which is required on iOS 26+ where `UITabBar.isHidden` workarounds from
+   * outside React Native no longer reach the SwiftUI-backed tab bar.
+   */
+  tabBarHidden?: boolean;
 }
 
 const ANDROID_MAX_TABS = 100;
@@ -247,6 +255,7 @@ const TabView = <Route extends BaseRoute>({
   labeled = Platform.OS !== 'android' ? true : undefined,
   getFreezeOnBlur = ({ route }: { route: Route }) => route.freezeOnBlur,
   tabBar: renderCustomTabBar,
+  tabBarHidden,
   tabBarStyle,
   tabLabelStyle,
   renderBottomAccessoryView,
@@ -404,7 +413,7 @@ const TabView = <Route extends BaseRoute>({
         // When rendering a custom tab bar, icons can be React elements, which will not be properly resolved.
         icons={renderCustomTabBar ? undefined : resolvedIconAssets}
         selectedPage={focusedKey}
-        tabBarHidden={!!renderCustomTabBar}
+        tabBarHidden={tabBarHidden ?? !!renderCustomTabBar}
         onTabLongPress={handleTabLongPress}
         onPageSelected={handlePageSelected}
         onTabBarMeasured={handleTabBarMeasured}

--- a/packages/react-native-bottom-tabs/src/TabView.tsx
+++ b/packages/react-native-bottom-tabs/src/TabView.tsx
@@ -418,7 +418,7 @@ const TabView = <Route extends BaseRoute>({
         // When rendering a custom tab bar, icons can be React elements, which will not be properly resolved.
         icons={renderCustomTabBar ? undefined : resolvedIconAssets}
         selectedPage={focusedKey}
-        tabBarHidden={tabBarHidden ?? !!renderCustomTabBar}
+        tabBarHidden={tabBarHidden}
         onTabLongPress={handleTabLongPress}
         onPageSelected={handlePageSelected}
         onTabBarMeasured={handleTabBarMeasured}

--- a/packages/react-native-bottom-tabs/src/TabView.tsx
+++ b/packages/react-native-bottom-tabs/src/TabView.tsx
@@ -259,7 +259,7 @@ const TabView = <Route extends BaseRoute>({
   labeled = Platform.OS !== 'android' ? true : undefined,
   getFreezeOnBlur = ({ route }: { route: Route }) => route.freezeOnBlur,
   tabBar: renderCustomTabBar,
-  tabBarHidden = false,
+  tabBarHidden,
   tabBarStyle,
   tabLabelStyle,
   renderBottomAccessoryView,
@@ -418,7 +418,7 @@ const TabView = <Route extends BaseRoute>({
         // When rendering a custom tab bar, icons can be React elements, which will not be properly resolved.
         icons={renderCustomTabBar ? undefined : resolvedIconAssets}
         selectedPage={focusedKey}
-        tabBarHidden={tabBarHidden}
+        tabBarHidden={tabBarHidden ?? !!renderCustomTabBar}
         onTabLongPress={handleTabLongPress}
         onPageSelected={handlePageSelected}
         onTabBarMeasured={handleTabBarMeasured}

--- a/packages/react-native-bottom-tabs/src/TabView.tsx
+++ b/packages/react-native-bottom-tabs/src/TabView.tsx
@@ -213,11 +213,7 @@ interface Props<Route extends BaseRoute> {
    */
   layoutDirection?: LayoutDirection;
   /**
-   * Whether to hide the native tab bar. Defaults to `true` when a custom
-   * `tabBar` is provided (so the native bar does not stack on top of the
-   * custom one), otherwise `false`. Set explicitly to override the default,
-   * which is required on iOS 26+ where `UITabBar.isHidden` workarounds from
-   * outside React Native no longer reach the SwiftUI-backed tab bar.
+   * Whether to hide the native tab bar.
    */
   tabBarHidden?: boolean;
 }
@@ -255,7 +251,7 @@ const TabView = <Route extends BaseRoute>({
   labeled = Platform.OS !== 'android' ? true : undefined,
   getFreezeOnBlur = ({ route }: { route: Route }) => route.freezeOnBlur,
   tabBar: renderCustomTabBar,
-  tabBarHidden,
+  tabBarHidden = false,
   tabBarStyle,
   tabLabelStyle,
   renderBottomAccessoryView,


### PR DESCRIPTION
Closes #521.

`tabBarHidden` is wired natively (SwiftUI `.hideTabBar(props.tabBarHidden)`, landed in #76) but the JS wrapper in `packages/react-native-bottom-tabs/src/TabView.tsx` hardcoded `tabBarHidden={!!renderCustomTabBar}` after the `{...props}` spread, so any caller-supplied value was overwritten before it reached `NativeTabView`. The prop was also absent from the `Props<Route>` interface so it never surfaced at the type level either.

This PR:
- adds `tabBarHidden?: boolean` to the `TabView` `Props<Route>` interface with a JSDoc note that explains the default and the iOS 26+ use case from the issue
- destructures it from the function parameters alongside the other named props
- keeps the existing `!!renderCustomTabBar` behavior as the fallback when the caller does not pass a value (`tabBarHidden ?? !!renderCustomTabBar`)

Effect:
- callers can now set `<TabView ... tabBarHidden={true} />` to hide the native bar without rendering a custom `tabBar`, which is what the issue needs on iOS 26 where the `UITabBar.isHidden` workarounds from outside React Native no longer reach the SwiftUI-backed bar
- callers that do not pass `tabBarHidden` get the same behavior as before (hidden iff `tabBar` is provided)
- TypeScript users see the prop in IntelliSense and on the public type

Verification:
- `tsc -b` clean on the package
- `eslint packages/react-native-bottom-tabs/src/TabView.tsx` reports only the pre-existing `no-shadow` warning on `loaded` (line 293), unrelated to this change
- existing jest setup in this repo is `it.todo('write a test')` and `yarn test` fails on `main` due to Flow type syntax in `react-native/jest/setup.js`, so a behavioural test would require fixing the jest config first which is outside the scope of this PR
- changeset added: `.changeset/respect-user-tab-bar-hidden.md` (`react-native-bottom-tabs: patch`)

Out of scope:
- the React Navigation adapter package (`@bottom-tabs/react-navigation`) does not reference `tabBarHidden`, so the `<Tabs.Navigator tabBarHidden={shouldHide}>` mention in the issue would need a separate change in that package's screen-options forwarding