### PR TITLE
fix(ios): gate index>=4 appear-select on >5-tab overflow

### DIFF
--- a/.changeset/bright-taxes-cheat.md
+++ b/.changeset/bright-taxes-cheat.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+Fix phantom tab switch on iOS when scene re-appears

--- a/packages/react-native-bottom-tabs/ios/TabAppearModifier.swift
+++ b/packages/react-native-bottom-tabs/ios/TabAppearModifier.swift
@@ -18,7 +18,12 @@ struct TabAppearModifier: ViewModifier {
       #endif
 
       #if os(iOS)
-        if context.index >= 4, context.props.selectedPage != context.tabData.key {
+        // Sync selection for tabs nested under the system "More" tab, which
+        // only exists when there are more than 5 visible tabs. Without the
+        // count guard the 5th tab (index 4) of a non-overflowing bar would
+        // force-select itself whenever its scene re-appears (e.g. when the tab
+        // bar is re-shown after `.hideTabBar`), hijacking the selection.
+        if context.props.filteredItems.count > 5, context.index >= 4, context.props.selectedPage != context.tabData.key {
           context.onSelect(context.tabData.key)
         }
       #endif


### PR DESCRIPTION
## Summary

Fixes #525.

On iOS, `TabAppearModifier` force-selects any tab with `index >= 4` in `onAppear` to sync selection for tabs nested under iOS's **"More"** overflow tab. That overflow only exists when there are **more than 5 visible tabs**. With exactly 5 tabs there is no More tab, yet the 5th tab (index 4) still matches `index >= 4`, so it steals the selection whenever its scene re-appears — most visibly when the tab bar is re-shown after a screen hid it via `.hideTabBar` — causing a phantom tab switch that JS can't correct (`selectedPage` is a value-diffed controlled prop).

## Change

Gate the force-select on actual overflow (`filteredItems.count > 5`), so it only runs when a real "More" tab exists.

```diff
 #if os(iOS)
-  if context.index >= 4, context.props.selectedPage != context.tabData.key {
+  if context.props.filteredItems.count > 5, context.index >= 4, context.props.selectedPage != context.tabData.key {
     context.onSelect(context.tabData.key)
   }
 #endif
```

## Behavior

- **>5 tabs (More menu):** unchanged — the appear-sync still runs for overflowed tabs.
- **≤5 tabs:** the spurious force-select no longer fires, so the 5th tab stops hijacking the selection on re-appear.

## Testing

Verified on a 5-tab app (`@bottom-tabs/react-navigation` + expo-router) with a real device build: returning from a `tabBarHidden` screen no longer jumps to the 5th tab; normal tab switching and the >5-tab More flow are unaffected.
