### PR TITLE
fix(#534): render badges in standalone docs guide

### DIFF
--- a/docs/docs/docs/guides/standalone-usage.mdx
+++ b/docs/docs/docs/guides/standalone-usage.mdx
@@ -1,3 +1,5 @@
+import { Badge } from '@theme';
+
 # Standalone usage
 
 If you don't use React Navigation, you can use the `TabView` component directly.


### PR DESCRIPTION
## Summary
- rename the standalone usage guide from Markdown to MDX so inline JSX components are parsed
- import `Badge` from `@theme` at the top of the guide

## Why
The page already uses inline `<Badge />` components, but plain Markdown does not evaluate them. Converting the guide to MDX makes those badges render the same way they do in the other docs pages.

## Validation
- `node .yarn/releases/yarn-4.6.0.cjs workspace react-native-bottom-tabs-docs build`
