### PR TITLE
fix: fix js bottom tabs crashing on contacts in example

### DIFF
--- a/apps/example/src/Screens/Contacts.tsx
+++ b/apps/example/src/Screens/Contacts.tsx
@@ -11,7 +11,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import { useBottomTabBarHeight } from 'react-native-bottom-tabs';
+import { BottomTabBarHeightContext } from 'react-native-bottom-tabs';
 import { MusicControl } from '../Components/MusicControl';
 
 type Item = { name: string; number: number };
@@ -104,7 +104,7 @@ export function Contacts({ query, ...rest }: Props) {
   console.log(Platform.OS, ' Rendering Contacts');
   const renderItem = ({ item }: { item: Item }) => <ContactItem item={item} />;
 
-  const tabBarHeight = useBottomTabBarHeight();
+  const tabBarHeight = React.useContext(BottomTabBarHeightContext) ?? 0;
   const ref = React.useRef<FlatList>(null);
   useScrollToTop(ref);
 


### PR DESCRIPTION
<!-- Please provide information about your pull request. -->

## PR Description

Bug fix.

Fixes the runtime crash in the **JS Bottom Tabs** example when switching to the **Contacts** tab:

> Couldn't find the bottom tab bar height. Are you inside a screen in Native Bottom Tab Navigator?

**Root cause:** The Contacts.tsx screen is shared by all example navigators, and was using the `useBottomTabBarHeight` import. This threw because of a missing context in the JS implementation, as it used the JS implementation instead of the Native Implementation.

This fix should read from the context safely, and fallback to a nullish coalescence value to prevent any errors.


## How to test?

- Run the example app.
- Scroll down to the JS Tabs examples.
- Navigate to the Contacts tabs.
- Contacts tabs should now render as intended and not throw an error.

## Screenshots

<!-- If applicable, add screenshots or videos to help explain your changes. -->

https://github.com/user-attachments/assets/6cfc2124-be11-447f-bed5-5aeb2cd52b86

Closes #533 
