### PR TITLE
fix(iOS): add compile guard iOS 26 SwiftUI symbol

### DIFF
--- a/.changeset/fix-compiler-guards-ios26.md
+++ b/.changeset/fix-compiler-guards-ios26.md
@@ -1,0 +1,5 @@
+---
+"react-native-bottom-tabs": patch
+---
+
+Add `#if compiler(>=6.2)` guards to iOS-26 SwiftUI symbols in BottomAccessoryProvider.swift and NewTabView.swift to fix compilation on Xcode < 26

--- a/packages/react-native-bottom-tabs/ios/BottomAccessoryProvider.swift
+++ b/packages/react-native-bottom-tabs/ios/BottomAccessoryProvider.swift
@@ -8,7 +8,7 @@ import SwiftUI
     self.delegate = delegate
   }
 
-  #if !os(macOS)
+  #if !os(macOS) && compiler(>=6.2)
   @available(iOS 26.0, tvOS 26.0, *)
   public func emitPlacementChanged(_ placement: TabViewBottomAccessoryPlacement?) {
     var placementValue = "none"

--- a/packages/react-native-bottom-tabs/ios/TabView/NewTabView.swift
+++ b/packages/react-native-bottom-tabs/ios/TabView/NewTabView.swift
@@ -79,7 +79,7 @@ struct ConditionalBottomAccessoryModifier: ViewModifier {
   }
 
   func body(content: Content) -> some View {
-    #if os(macOS) || os(tvOS)
+    #if os(macOS) || os(tvOS) || !compiler(>=6.2)
     // tabViewBottomAccessory is not available on macOS
     content
     #else
@@ -96,7 +96,7 @@ struct ConditionalBottomAccessoryModifier: ViewModifier {
 
   @ViewBuilder
   private func renderBottomAccessoryView() -> some View {
-    #if !os(macOS) && !os(tvOS)
+    #if !os(macOS) && !os(tvOS) && compiler(>=6.2)
     if let bottomAccessoryView {
       if #available(iOS 26.0, *) {
         BottomAccessoryRepresentableView(view: bottomAccessoryView)
@@ -106,7 +106,7 @@ struct ConditionalBottomAccessoryModifier: ViewModifier {
   }
 }
 
-#if !os(macOS) && !os(tvOS)
+#if !os(macOS) && !os(tvOS) && compiler(>=6.2)
 @available(iOS 26.0, tvOS 26.0, *)
 struct BottomAccessoryRepresentableView: PlatformViewRepresentable {
   @Environment(\.tabViewBottomAccessoryPlacement) var tabViewBottomAccessoryPlacement


### PR DESCRIPTION
## PR Description

 - Bug fix. iOS-26 SwiftUI symbols `(TabViewBottomAccessoryPlacement, .tabViewBottomAccessory, .tabViewBottomAccessoryPlacement)` are guarded only by runtime `@available` checks in `BottomAccessoryProvider.swift` and `NewTabView.swift`, so the package fails to compile on Xcode < 26 with `cannot find type … in scope`. 
 - Add `#if compiler(>=6.2)` compile-time guards matching the pattern already used in `TabViewProps.swift` and  
  `TabViewImpl.swift`

## How to test?

  1. Open the project in Xcode 16 (Swift < 6.2)                                                                                                                                                                       
  2. Build for iOS — should compile without errors
  3. Open the project in Xcode 26 (Swift 6.2+)
  4. Build for iOS — should work as before

## Screenshots

N/A
