### PR TITLE
ci: fix release error premature close

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
+          check-latest: true
           node-version-file: '.nvmrc'
 
       - name: Install Dependencies


### PR DESCRIPTION
<!-- Please provide information about your pull request. -->

## PR Description

<!-- What kind of change does this PR introduce? (Bug fix, feature, docs update, ...) -->

The release action has been failing on latest commits because of a change introduced in Node.js that tricks node-fetch to think the request has failed, while it did not.

This has already been patched in Node and we just need to force the workflow to use the latest patch.