### PR TITLE
fix(android): keep BottomNavigationView pinned under the keyboard in edge-to-edge

### DIFF
--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -21,6 +21,8 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.view.MenuItemCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.forEachIndexed
 import coil3.ImageLoader
 import coil3.asDrawable
@@ -40,6 +42,29 @@ import com.google.android.material.navigation.NavigationBarView.LABEL_VISIBILITY
 import com.google.android.material.transition.platform.MaterialFadeThrough
 
 class ExtendedBottomNavigationView(context: Context) : BottomNavigationView(context) {
+  init {
+    // Material's BottomNavigationView adds the bottom system-window inset (which includes
+    // the IME inset under edge-to-edge) to its own padding, so the bar rises above the
+    // keyboard. Re-listen with system bars + display cutout only, excluding the IME type,
+    // so the bar stays pinned and the keyboard overlays it, matching iOS.
+    val baseLeft = paddingLeft
+    val baseTop = paddingTop
+    val baseRight = paddingRight
+    val baseBottom = paddingBottom
+    ViewCompat.setOnApplyWindowInsetsListener(this) { view, insets ->
+      val bars = insets.getInsets(
+        WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+      )
+      view.setPadding(
+        baseLeft + bars.left,
+        baseTop,
+        baseRight + bars.right,
+        baseBottom + bars.bottom,
+      )
+      insets
+    }
+  }
+
   override fun getMaxItemCount(): Int {
     return 100
   }


### PR DESCRIPTION
## What

Under edge-to-edge on Android, focusing a text input pushes the native tab bar up on top of the keyboard instead of letting the keyboard overlay it (iOS behavior). Fixes #357.

## Why

The library delegates inset handling to Material. `BottomNavigationView` installs a default inset listener in its constructor that adds `getSystemWindowInsetBottom()` to its bottom padding, and that value includes the IME inset. With `decorFitsSystemWindows=false` the window is not resized, so the IME inset propagates down to the bar and Material pads it by the keyboard height every frame (material-components/material-components-android#493). `windowSoftInputMode="adjustPan"` does not help when `react-native-keyboard-controller` is present, since it forces `adjustResize` at runtime.

## How

Give `ExtendedBottomNavigationView` its own `OnApplyWindowInsetsListener` that applies system bars + display cutout insets only, excluding `Type.ime()`, and returns the insets unconsumed so sibling views (the tab-screen content that hosts inputs) still receive the IME inset. Gesture-nav clearance is preserved because system-bar and cutout insets are still applied as padding.

This is a no-op outside edge-to-edge: with `decorFitsSystemWindows=true` the decor consumes the system insets before they reach the bar, so the computed insets are zero and padding stays at its base, and the keyboard resizes the window rather than dispatching an IME inset. Behavior only changes for the edge-to-edge case that is currently broken.

## Test plan

- Edge-to-edge app, tab-root screen with a top input: focus the input, confirm the tab bar stays pinned and the keyboard overlays it.
- Form screen with a bottom input inside a tab: confirm keyboard avoidance still works.
- Non-edge-to-edge build: confirm no change (bar still clears the nav bar, keyboard resizes as before).
- Landscape / gesture-nav and 3-button nav: confirm the bar still clears the system nav bar.
