### PR TITLE
fix(android): expose tab test IDs to UIAutomator

### DIFF
--- a/.changeset/maestro-android-testid.md
+++ b/.changeset/maestro-android-testid.md
@@ -1,0 +1,5 @@
+---
+"react-native-bottom-tabs": patch
+---
+
+Expose Android tab button test IDs as accessibility resource IDs for UIAutomator-based E2E tools.

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -20,7 +20,10 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.view.AccessibilityDelegateCompat
 import androidx.core.view.MenuItemCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.forEachIndexed
 import coil3.ImageLoader
 import coil3.asDrawable
@@ -281,12 +284,7 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
             onTabSelected(menuItem)
           }
 
-          item.testID?.let { testId ->
-            view.findViewById<View>(com.google.android.material.R.id.navigation_bar_item_content_container)
-              ?.apply {
-                tag = testId
-              }
-          }
+          applyTestID(view, item.testID)
         }
       }
     }
@@ -299,6 +297,28 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
 
   private fun getOrCreateItem(index: Int, title: String): MenuItem {
     return bottomNavigation.menu.findItem(index) ?: bottomNavigation.menu.add(0, index, 0, title)
+  }
+
+  private fun applyTestID(itemView: View, testID: String?) {
+    val contentContainer =
+      itemView.findViewById<View>(com.google.android.material.R.id.navigation_bar_item_content_container)
+        ?: return
+
+    contentContainer.tag = testID
+    if (testID == null) {
+      ViewCompat.setAccessibilityDelegate(contentContainer, null)
+      return
+    }
+
+    ViewCompat.setAccessibilityDelegate(contentContainer, object : AccessibilityDelegateCompat() {
+      override fun onInitializeAccessibilityNodeInfo(
+        host: View,
+        info: AccessibilityNodeInfoCompat
+      ) {
+        super.onInitializeAccessibilityNodeInfo(host, info)
+        info.viewIdResourceName = testID
+      }
+    })
   }
 
   private fun updateIconTintMode(menuItem: MenuItem, item: TabInfo) {


### PR DESCRIPTION
## Summary
- Exposes Android tab button test IDs through `AccessibilityNodeInfoCompat.viewIdResourceName` so UIAutomator-based tools like Maestro can find them as resource IDs.
- Keeps the existing tab content container tag behavior and clears stale test ID state when a reused tab item no longer has one.
- Adds a patch changeset for `react-native-bottom-tabs`.

Fixes #550

## Testing
- `yarn workspace react-native-bottom-tabs typecheck`
- `./gradlew --no-daemon --console=plain :ReactNativeBottomTabs:build` from `apps/example/android`

## Notes
- Package lint was not run successfully: `yarn workspace react-native-bottom-tabs lint` fails to start in this workspace because `eslint` is not provided to the package under Yarn PnP.