### PR TITLE
fix: expose Android tab button test IDs

### DIFF
--- a/.changeset/android-tab-test-ids.md
+++ b/.changeset/android-tab-test-ids.md
@@ -1,0 +1,6 @@
+---
+"react-native-bottom-tabs": patch
+"@bottom-tabs/react-navigation": patch
+---
+
+Expose Android tab button test IDs to UIAutomator-based E2E tools.

--- a/apps/example/e2e/native-tabs-test-id.yaml
+++ b/apps/example/e2e/native-tabs-test-id.yaml
@@ -1,7 +1,5 @@
 appId: bottomtabs.example
-name: Android native tabs testID smoke
-tags:
-  - smoke
+name: Navigate tabs via testIDs
 ---
 - launchApp
 - scrollUntilVisible:

--- a/apps/example/e2e/native-tabs-test-id.yaml
+++ b/apps/example/e2e/native-tabs-test-id.yaml
@@ -1,0 +1,22 @@
+appId: bottomtabs.example
+name: Android native tabs testID smoke
+tags:
+  - smoke
+---
+- launchApp
+- scrollUntilVisible:
+    element:
+      text: ^Native Bottom Tabs$
+    direction: DOWN
+    timeout: 15000
+- tapOn:
+    text: ^Native Bottom Tabs$
+- assertVisible: Press me
+- tapOn:
+    id: articleTestID
+- assertVisible: What is Lorem Ipsum?
+- tapOn:
+    id: albumsTestID
+- tapOn:
+    id: chatTestID
+- assertVisible: Press me

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -7,6 +7,7 @@
     "build:android": "npm run mkdist && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist && react-native build-android --extra-params \"--no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a -PnewArchEnabled=true\"",
     "build:ios": "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
     "ios": "react-native run-ios",
+    "e2e:android": "maestro test --platform=android e2e",
     "mkdist": "node -e \"require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })\"",
     "start": "react-native start"
   },

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -7,6 +7,7 @@
     "build:android": "npm run mkdist && react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist && react-native build-android --extra-params \"--no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a -PnewArchEnabled=true\"",
     "build:ios": "npm run mkdist && react-native bundle --entry-file index.js --platform ios --dev true --bundle-output dist/main.ios.jsbundle --assets-dest dist",
     "ios": "react-native run-ios",
+    "e2e:ios": "maestro test --platform=ios e2e",
     "e2e:android": "maestro test --platform=android e2e",
     "mkdist": "node -e \"require('node:fs').mkdirSync('dist', { recursive: true, mode: 0o755 })\"",
     "start": "react-native start"

--- a/apps/example/src/Examples/NativeBottomTabs.tsx
+++ b/apps/example/src/Examples/NativeBottomTabs.tsx
@@ -60,6 +60,7 @@ function NativeBottomTabs() {
         name="Albums"
         component={Albums}
         options={{
+          tabBarButtonTestID: 'albumsTestID',
           tabBarIcon: () => require('../../assets/icons/grid_dark.png'),
         }}
       />
@@ -72,6 +73,7 @@ function NativeBottomTabs() {
           },
         }}
         options={{
+          tabBarButtonTestID: 'contactsTestID',
           tabBarIcon: () => require('../../assets/icons/person_dark.png'),
           tabBarActiveTintColor: 'yellow',
           preventsDefault: true,
@@ -86,6 +88,7 @@ function NativeBottomTabs() {
           },
         }}
         options={{
+          tabBarButtonTestID: 'chatTestID',
           tabBarIcon: () => require('../../assets/icons/chat_dark.png'),
           tabBarActiveTintColor: 'white',
         }}

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -302,15 +302,18 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
 
   private fun View.setTabTestID(testId: String?) {
     tag = testId
+    if (testId == null) {
+      ViewCompat.setAccessibilityDelegate(this, null)
+      return
+    }
+
     ViewCompat.setAccessibilityDelegate(this, object : AccessibilityDelegateCompat() {
       override fun onInitializeAccessibilityNodeInfo(
         host: View,
         info: AccessibilityNodeInfoCompat
       ) {
         super.onInitializeAccessibilityNodeInfo(host, info)
-        testId?.let {
-          info.viewIdResourceName = it
-        }
+        info.viewIdResourceName = testId
       }
     })
   }

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -20,7 +20,10 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.view.AccessibilityDelegateCompat
 import androidx.core.view.MenuItemCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.forEachIndexed
 import coil3.ImageLoader
 import coil3.asDrawable
@@ -281,12 +284,8 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
             onTabSelected(menuItem)
           }
 
-          item.testID?.let { testId ->
-            view.findViewById<View>(com.google.android.material.R.id.navigation_bar_item_content_container)
-              ?.apply {
-                tag = testId
-              }
-          }
+          view.findViewById<View>(com.google.android.material.R.id.navigation_bar_item_content_container)
+            ?.setTabTestID(item.testID)
         }
       }
     }
@@ -299,6 +298,21 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
 
   private fun getOrCreateItem(index: Int, title: String): MenuItem {
     return bottomNavigation.menu.findItem(index) ?: bottomNavigation.menu.add(0, index, 0, title)
+  }
+
+  private fun View.setTabTestID(testId: String?) {
+    tag = testId
+    ViewCompat.setAccessibilityDelegate(this, object : AccessibilityDelegateCompat() {
+      override fun onInitializeAccessibilityNodeInfo(
+        host: View,
+        info: AccessibilityNodeInfoCompat
+      ) {
+        super.onInitializeAccessibilityNodeInfo(host, info)
+        testId?.let {
+          info.viewIdResourceName = it
+        }
+      }
+    })
   }
 
   private fun updateIconTintMode(menuItem: MenuItem, item: TabInfo) {


### PR DESCRIPTION
## Summary
- expose Android tab button test IDs to UIAutomator-based tools
- add an Android Maestro smoke flow for native tabs

Fixes #550