### PR TITLE
ci: stop updating npm during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
-      - name: Update npm
-        run: npm install -g npm@latest # to ensure Trusted Publishing works correctly
-
       - name: Create Release Pull Request or Publish to NPM
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:


### PR DESCRIPTION
## Summary

Remove the release workflow step that globally upgrades npm with `npm install -g npm@latest` before running Changesets publish.

## Why

The failed release run for #544 reached the publish phase, but npm's provenance path failed with `MODULE_NOT_FOUND Cannot find module 'sigstore'` after the workflow replaced the runner-provided npm installation. The Node 24 runner already provides npm 11.16.0, which is provenance-capable, so the global npm replacement is unnecessary and appears to be the source of the broken npm dependency tree.
