### PR TITLE
fix: report content size to JS when tab bar visibility changes on Android

### DIFF
--- a/.changeset/tall-donkeys-resize.md
+++ b/.changeset/tall-donkeys-resize.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+Fix Android content not resizing when the tab bar visibility changes (`tabBarHidden`). The layout listener compared the container bounds, which stay the same when only the tab bar is hidden or shown, so the new `layoutHolder` size was never reported to JS and the content kept its stale height.

--- a/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
+++ b/packages/react-native-bottom-tabs/android/src/main/java/com/rcttabview/RCTTabView.kt
@@ -100,22 +100,33 @@ class ReactBottomNavigationView(context: Context) : LinearLayout(context) {
     uiModeConfiguration = resources.configuration.uiMode
 
     post {
-      addOnLayoutChangeListener { _, left, top, right, bottom,
+      addOnLayoutChangeListener { _, _, _, _, _,
                                   _, _, _, _ ->
-        val newWidth = right - left
-        val newHeight = bottom - top
-
         // Notify about tab bar height.
         onTabBarMeasuredListener?.invoke(Utils.convertPixelsToDp(context, bottomNavigation.height).toInt())
 
-        if (newWidth != lastReportedSize?.width || newHeight != lastReportedSize?.height) {
-          val dpWidth = Utils.convertPixelsToDp(context, layoutHolder.width)
-          val dpHeight = Utils.convertPixelsToDp(context, layoutHolder.height)
-
-          onNativeLayoutListener?.invoke(dpWidth, dpHeight)
-          lastReportedSize = Size(newWidth, newHeight)
-        }
+        reportLayoutHolderSizeIfChanged()
       }
+      // When only the tab bar visibility changes (tabBarHidden), the container keeps
+      // its bounds so the listener above never fires — only layoutHolder grows or
+      // shrinks. Observe layoutHolder itself so the new content size reaches JS.
+      layoutHolder.addOnLayoutChangeListener { _, _, _, _, _,
+                                               _, _, _, _ ->
+        reportLayoutHolderSizeIfChanged()
+      }
+    }
+  }
+
+  private fun reportLayoutHolderSizeIfChanged() {
+    val newWidth = layoutHolder.width
+    val newHeight = layoutHolder.height
+
+    if (newWidth != lastReportedSize?.width || newHeight != lastReportedSize?.height) {
+      val dpWidth = Utils.convertPixelsToDp(context, newWidth)
+      val dpHeight = Utils.convertPixelsToDp(context, newHeight)
+
+      onNativeLayoutListener?.invoke(dpWidth, dpHeight)
+      lastReportedSize = Size(newWidth, newHeight)
     }
   }
 


### PR DESCRIPTION
## PR Description

Fixes #557

Bug fix. On Android, toggling `tabBarHidden` didn't resize the React content. The layout listener's size-change guard compares the bounds of the whole `ReactBottomNavigationView` container, but hiding/showing the tab bar doesn't change the container bounds — only the inner `layoutHolder` grows or shrinks. On top of that, the listener is attached to the container, so `OnLayoutChangeListener` doesn't even fire in that case. As a result `onNativeLayoutListener` never reported the new size, `setMeasuredDimensions` on the JS side kept the stale height, and the content stayed short with a blank strip where the tab bar used to be.

Changes:

- Compare and report the `layoutHolder` size (which is what was already being sent to JS anyway) instead of the container size, extracted into `reportLayoutHolderSizeIfChanged()`.
- Also observe `layoutHolder` layout changes, so the visibility-toggle case (container bounds unchanged) is caught.

## How to test?

1. In an Android app using `createNativeBottomTabNavigator`, render a screen with a bottom-anchored view (`position: 'absolute', bottom: 0`).
2. Toggle `tabBarHidden` to `true`.
3. Before this change: the bottom-anchored view stays at the tab bar's old top edge, with an empty strip below it. After: the content fills the reclaimed space and the view sits at the actual bottom of the screen.
4. Toggle back to `false` — the content shrinks back above the tab bar.

Verified on an Android 16 emulator (RN 0.86, New Architecture) with `uiautomator dump`: previously the React subtree stayed at 2126px while the native `layoutHolder` grew to 2400px after hiding the tab bar; with this change both match, in both directions.

## Screenshots

N/A — measurement/layout change, behavior described above.
