### PR TITLE
fix: measure custom tab bar height with onLayout

### DIFF
--- a/.changeset/great-cases-clap.md
+++ b/.changeset/great-cases-clap.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': patch
+---
+
+Fix custom tab bar height measurement for absolutely positioned tab bars. `useBottomTabBarHeight` now reports the correct height when `renderCustomTabBar` returns an absolutely positioned element, by measuring it with `onLayout` instead of measuring the wrapper `View`.

--- a/packages/react-native-bottom-tabs/src/TabView.tsx
+++ b/packages/react-native-bottom-tabs/src/TabView.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef } from 'react';
+import React from 'react';
 import type {
   OnNativeLayout,
   OnPageSelectedEventData,
@@ -9,6 +9,7 @@ import {
   type ColorValue,
   type DimensionValue,
   Image,
+  type LayoutChangeEvent,
   Platform,
   type StyleProp,
   StyleSheet,
@@ -281,8 +282,11 @@ const TabView = <Route extends BaseRoute>({
 }: Props<Route>) => {
   // @ts-ignore
   const focusedKey = navigationState.routes[navigationState.index].key;
-  const customTabBarWrapperRef = useRef<View>(null);
   const [tabBarHeight, setTabBarHeight] = React.useState<number | undefined>(0);
+  const [customTabBarWrapperHeight, setCustomTabBarWrapperHeight] =
+    React.useState(0);
+  const [customTabBarElementHeight, setCustomTabBarElementHeight] =
+    React.useState(0);
   const [measuredDimensions, setMeasuredDimensions] = React.useState<
     { width: DimensionValue; height: DimensionValue } | undefined
   >({ width: '100%', height: '100%' });
@@ -442,17 +446,36 @@ const TabView = <Route extends BaseRoute>({
     [setMeasuredDimensions]
   );
 
-  useLayoutEffect(() => {
-    // If we are rendering a custom tab bar, we need to measure it to set the tab bar height.
-    if (renderCustomTabBar && customTabBarWrapperRef.current) {
-      customTabBarWrapperRef.current.measure((_x, _y, _width, height) => {
-        setTabBarHeight(height);
-      });
-    }
-  }, [renderCustomTabBar]);
+  const handleCustomTabBarWrapperLayout = React.useCallback(
+    (event: LayoutChangeEvent) => {
+      setCustomTabBarWrapperHeight(event.nativeEvent.layout.height);
+    },
+    []
+  );
+
+  const handleCustomTabBarElementLayout = React.useCallback(
+    (event: LayoutChangeEvent) => {
+      setCustomTabBarElementHeight(event.nativeEvent.layout.height);
+    },
+    []
+  );
+
+  const customTabBar = renderCustomTabBar?.();
+  const customTabBarElement = React.isValidElement<{
+    onLayout?: (event: LayoutChangeEvent) => void;
+  }>(customTabBar)
+    ? customTabBar
+    : null;
+  const customTabBarHeight = Math.max(
+    customTabBarWrapperHeight,
+    // Drop a stale element height once the tab bar stops rendering an element to measure.
+    customTabBarElement ? customTabBarElementHeight : 0
+  );
 
   return (
-    <BottomTabBarHeightContext.Provider value={tabBarHeight}>
+    <BottomTabBarHeightContext.Provider
+      value={renderCustomTabBar ? customTabBarHeight : tabBarHeight}
+    >
       <NativeTabView
         {...props}
         {...tabLabelStyle}
@@ -529,7 +552,16 @@ const TabView = <Route extends BaseRoute>({
         ) : null}
       </NativeTabView>
       {renderCustomTabBar ? (
-        <View ref={customTabBarWrapperRef}>{renderCustomTabBar()}</View>
+        <View onLayout={handleCustomTabBarWrapperLayout}>
+          {customTabBarElement
+            ? React.cloneElement(customTabBarElement, {
+                onLayout: (event: LayoutChangeEvent) => {
+                  customTabBarElement.props.onLayout?.(event);
+                  handleCustomTabBarElementLayout(event);
+                },
+              })
+            : customTabBar}
+        </View>
       ) : null}
     </BottomTabBarHeightContext.Provider>
   );


### PR DESCRIPTION
## PR Description

Bug fix. Closes #380.

`TabView` measured the custom tab bar by calling `.measure()` on the wrapper `View` in a `useLayoutEffect`. Absolutely positioned children don't contribute to their parent's measured size, so for a `renderCustomTabBar` that returns an absolutely positioned element the wrapper measured `0` and `useBottomTabBarHeight()` returned `0`.

Changes:

- Removed the `ref` + `useLayoutEffect` + `.measure()` logic.
- The element returned by `renderCustomTabBar` is now cloned with an injected `onLayout` (any `onLayout` the element already declares is still called), and the wrapper keeps its own `onLayout`.
- The reported height is the larger of the two, so regular tab bars keep the wrapper measurement and absolutely positioned ones get the element's own height. Non-element return values (fragments, arrays) still fall back to the wrapper, preserving the previous behaviour.

## How to test?

Render a `TabView` with a custom tab bar that is absolutely positioned, and read the height from a screen:

```jsx
<TabView
  renderCustomTabBar={() => (
    <View style={{ position: 'absolute', bottom: 0, width: '100%', height: 60, backgroundColor: 'white' }} />
  )}
  // ...
/>
```

```jsx
const height = useBottomTabBarHeight(); // 0 before, 60 after
```

A non-absolutely-positioned custom tab bar should keep reporting the same height as before.

## Screenshots

N/A — no visual change to the library itself; the fix affects the value reported by `useBottomTabBarHeight()`.
