### PR TITLE
fix(expo-template): use development build instead of Expo Go

### DIFF
--- a/.changeset/expo-template-development-build.md
+++ b/.changeset/expo-template-development-build.md
@@ -1,0 +1,5 @@
+---
+'@bottom-tabs/expo-template': patch
+---
+
+Target development builds instead of Expo Go, and add `ios.bundleIdentifier` and `android.package` placeholders

--- a/packages/expo-template/README.md
+++ b/packages/expo-template/README.md
@@ -1,6 +1,6 @@
 # Welcome to your Expo + Native Tabs app 📱👋
 
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
+This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app). It uses [`react-native-bottom-tabs`](https://github.com/callstack/react-native-bottom-tabs) to render a real native tab bar.
 
 ## Get started
 
@@ -10,18 +10,19 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    npm install
    ```
 
-2. Start the app
+2. Build and run the app
 
    ```bash
-   npx expo start
+   npm run android
+   # or
+   npm run ios
    ```
 
-In the output, you'll find options to open the app in a
+   This creates a [development build](https://docs.expo.dev/develop/development-builds/introduction/), installs it on an [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/) or [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/), and starts the dev server. Once the app is installed, `npm start` is enough on its own.
 
-- [development build](https://docs.expo.dev/develop/development-builds/introduction/)
-- [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/)
-- [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
-- [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
+> **Note:** This project requires a development build. It cannot run in [Expo Go](https://expo.dev/go), which only bundles Expo's own native modules - and the native tab bar is not one of them.
+
+Before you build for a real device or a store, change `ios.bundleIdentifier` and `android.package` in **app.json** from `com.example.nativetabs` to your own identifiers.
 
 You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
 
@@ -39,6 +40,7 @@ This command will move the starter code to the **app-example** directory and cre
 
 To learn more about developing your project with Expo, look at the following resources:
 
+- [React Native Bottom Tabs documentation](https://oss.callstack.com/react-native-bottom-tabs/): Configure the native tab bar used in **app/(tabs)/\_layout.tsx**.
 - [Expo documentation](https://docs.expo.dev/): Learn fundamentals, or go into advanced topics with our [guides](https://docs.expo.dev/guides).
 - [Learn Expo tutorial](https://docs.expo.dev/tutorial/introduction/): Follow a step-by-step tutorial where you'll create a project that runs on Android, iOS, and the web.
 

--- a/packages/expo-template/app.json
+++ b/packages/expo-template/app.json
@@ -9,13 +9,15 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.example.nativetabs"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "package": "com.example.nativetabs"
     },
     "web": {
       "bundler": "metro",

--- a/packages/expo-template/gitignore
+++ b/packages/expo-template/gitignore
@@ -10,6 +10,8 @@ web-build/
 expo-env.d.ts
 
 # Native
+/android
+/ios
 *.orig.*
 *.jks
 *.p8

--- a/packages/expo-template/package.json
+++ b/packages/expo-template/package.json
@@ -3,10 +3,10 @@
   "main": "expo-router/entry",
   "version": "1.1.3",
   "scripts": {
-    "start": "expo start",
+    "start": "expo start --dev-client",
     "reset-project": "node ./scripts/reset-project.js",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest --watchAll"
   },


### PR DESCRIPTION
## PR Description

Bug fix for `@bottom-tabs/expo-template`. A scaffolded app couldn't be run with the scripts the template ships:

- **Scripts targeted Expo Go.** Expo Go only bundles Expo's own native modules, so it can never load `react-native-bottom-tabs`.
  `expo start --android` / `--ios` → `expo run:android` / `expo run:ios`, and `start` → `expo start --dev-client`. 
- **README advertised Expo Go** as a supported way to run. Rewritten around development builds.
- **App identifiers were unset.** Prebuild silently substitutes `com.placeholder.appid` for both platforms, so every scaffolded app shares one package name. Added `com.example.nativetabs` placeholders to `app.json` plus a README note to change them.
- **`gitignore` was missing `/android` and `/ios`,** leaving prebuild output untracked but not ignored.

Scripts, config, docs and a patch changeset only - no library changes.

## How to test?

Scaffold from the template on this branch, as `create-expo-app` would:

```bash
yarn workspace @bottom-tabs/expo-template pack --out /tmp/expo-template.tgz
npx create-expo-app@latest /tmp/tpl --template /tmp/expo-template.tgz
cd /tmp/tpl
```

- `npm run android` / `npm run ios` build and install a development build (previously opened Expo Go).
- `npm start` waits for a development build instead of offering Expo Go.
- `grep applicationId android/app/build.gradle` → `com.example.nativetabs`.
- `git init -q . && git add -A && git check-ignore -v android ios` → both ignored.

## Screenshots

Not applicable - no runtime or UI change.