### PR TITLE
feat(iOS): enable sidebarAdaptable on large enough screens

### DIFF
--- a/.changeset/sidebar-adaptable-large-iphone.md
+++ b/.changeset/sidebar-adaptable-large-iphone.md
@@ -1,0 +1,5 @@
+---
+'react-native-bottom-tabs': minor
+---
+
+Enable `sidebarAdaptable` on iOS for large enough screens.

--- a/docs/docs/docs/getting-started/how-is-it-different.mdx
+++ b/docs/docs/docs/getting-started/how-is-it-different.mdx
@@ -37,7 +37,7 @@ No need for custom scroll to top handling.
 
 ### Sidebar Adaptable
 
-TabView can turn in to a side bar on tvOS, iPadOS and macOS. This is controlled by `sidebarAdaptable` prop.
+TabView can turn into a sidebar on tvOS, iPadOS, macOS, and on iOS when the screen is large enough. This is controlled by the `sidebarAdaptable` prop. On iOS 27 (built with Xcode 27 or later), the bottom tab bar becomes a sidebar on large screens such as an unfolded iPhone Duo and switches back as the window shrinks.
 
 <video controls width="100%" src='https://github.com/user-attachments/assets/4093900f-2996-4c3a-8e15-de5b59aa53cc' />
 

--- a/docs/docs/docs/guides/standalone-usage.mdx
+++ b/docs/docs/docs/guides/standalone-usage.mdx
@@ -120,9 +120,13 @@ Whether to show labels in tabs. When `false`, only icons will be displayed.
 A tab bar style that adapts to each platform:
 
 - iPadOS: Top tab bar that can adapt into a sidebar
-- iOS: Bottom tab bar
+- iOS: Bottom tab bar. On iOS 27+ (built with Xcode 27 or later), large enough screens such as an unfolded iPhone Duo show a sidebar instead
 - macOS/tvOS: Sidebar
 - visionOS: Ornament with sidebar for secondary tabs
+
+Set `sidebarAdaptable` to `true` to opt in. Defaults to `false`.
+
+On iOS 27+, the placement follows the window size: the sidebar appears once the window is at least 920pt wide with a regular vertical size class (for example an unfolded iPhone Duo, or Resize Mode in Xcode's Device Hub), and the bottom tab bar returns when the window shrinks. Regular phones, including landscape, keep the bottom tab bar.
 
 #### `disablePageAnimations` <Badge text="iOS" type="info" />
 

--- a/docs/docs/docs/guides/usage-with-react-navigation.mdx
+++ b/docs/docs/docs/guides/usage-with-react-navigation.mdx
@@ -169,9 +169,13 @@ A tab bar style that adapts to each platform.
 Tab views using the sidebar adaptable style have an appearance
 
 - iPadOS displays a top tab bar that can adapt into a sidebar.
-- iOS displays a bottom tab bar.
+- iOS displays a bottom tab bar. On iOS 27+ (built with Xcode 27 or later), large enough screens such as an unfolded iPhone Duo display a sidebar instead.
 - macOS and tvOS always show a sidebar.
 - visionOS shows an ornament and also shows a sidebar for secondary tabs within a `TabSection`.
+
+Set `sidebarAdaptable` on `Tab.Navigator` to opt in. Defaults to `false`.
+
+On iOS 27+, the placement follows the window size: the sidebar appears once the window is at least 920pt wide with a regular vertical size class (for example an unfolded iPhone Duo, or Resize Mode in Xcode's Device Hub), and the bottom tab bar returns when the window shrinks. Regular phones, including landscape, keep the bottom tab bar.
 
 #### `hapticFeedbackEnabled`
 

--- a/packages/react-native-bottom-tabs/ios/TabView/NewTabView.swift
+++ b/packages/react-native-bottom-tabs/ios/TabView/NewTabView.swift
@@ -40,7 +40,7 @@ struct NewTabView: AnyTabView {
 
             Tab(value: tabData.key, role: tabData.role?.convert()) {
               RepresentableView(view: child.view)
-                .ignoresSafeArea(.container, edges: .all)
+                .modifier(TabContentLayoutModifier(onLayout: onLayout))
                 .tabAppear(using: context)
                 .hideTabBar(props.tabBarHidden)
             } label: {
@@ -61,10 +61,19 @@ struct NewTabView: AnyTabView {
       }
     }
     .environment(\.layoutDirection, effectiveLayoutDirection)
-    .measureView { size in
-      onLayout(size)
-    }
     .modifier(ConditionalBottomAccessoryModifier(props: props))
+  }
+}
+
+@available(iOS 18, macOS 15, visionOS 2, tvOS 18, *)
+private struct TabContentLayoutModifier: ViewModifier {
+  @Environment(\.tabBarPlacement) private var tabBarPlacement
+  var onLayout: (CGSize) -> Void
+
+  func body(content: Content) -> some View {
+    content
+      .ignoresSafeArea(.container, edges: tabBarPlacement == .sidebar ? .vertical : .all)
+      .measureView(onLayout: onLayout)
   }
 }
 

--- a/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewImpl.swift
@@ -426,6 +426,7 @@ extension View {
       if enabled {
         #if compiler(>=6.0)
           self.tabViewStyle(.sidebarAdaptable)
+            .modifier(AdaptiveSidebarPlacementModifier())
         #else
           self
         #endif
@@ -562,5 +563,27 @@ extension View {
     } else {
       self
     }
+  }
+}
+
+private struct AdaptiveSidebarPlacementModifier: ViewModifier {
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    #if os(iOS) && compiler(>=6.4)
+      if #available(iOS 27.0, *) {
+        content
+          .defaultTabBarPlacement(.sidebar)
+          .introspectTabView { controller in
+            guard controller.traitCollection.userInterfaceIdiom == .phone else { return }
+            // Tile the selected scene next to the sidebar so React Native measures the
+            // visible area instead of drawing underneath an overlapping sidebar.
+            controller.sidebar.preferredLayout = .tile
+          }
+      } else {
+        content
+      }
+    #else
+      content
+    #endif
   }
 }

--- a/packages/react-native-bottom-tabs/ios/TabViewProvider.swift
+++ b/packages/react-native-bottom-tabs/ios/TabViewProvider.swift
@@ -80,6 +80,9 @@ public final class TabInfo: NSObject {
   @objc public var sidebarAdaptable: Bool = false {
     didSet {
       props.sidebarAdaptable = sidebarAdaptable
+      #if os(iOS)
+        setNeedsLayout()
+      #endif
     }
   }
 
@@ -208,6 +211,39 @@ public final class TabInfo: NSObject {
   override public func layoutSubviews() {
     super.layoutSubviews()
     setupView()
+    #if os(iOS)
+      updateSidebarSizeClassOverride()
+    #endif
+  }
+#endif
+
+#if os(iOS)
+  /// Minimum width, in points, at which an iPhone window is wide enough for the sidebar.
+  /// UIKit keeps the iPhone sidebar collapsed below roughly 905pt even in a regular width, and
+  /// hides the tab bar at the same time, so stay a little above that. Phones never reach this
+  /// width in portrait, and landscape phones are excluded by their compact vertical size class.
+  private static let sidebarMinimumWidth: CGFloat = 920
+
+  private func updateSidebarSizeClassOverride() {
+    guard #available(iOS 27.0, *), let hostingController else { return }
+
+    let overrides = hostingController.traitOverrides
+    guard sidebarAdaptable, traitCollection.userInterfaceIdiom == .phone else {
+      if overrides.contains(UITraitHorizontalSizeClass.self) {
+        hostingController.traitOverrides.remove(UITraitHorizontalSizeClass.self)
+      }
+      return
+    }
+
+    let fitsSidebar =
+      traitCollection.verticalSizeClass == .regular
+      && bounds.width >= Self.sidebarMinimumWidth
+    let desired: UIUserInterfaceSizeClass = fitsSidebar ? .regular : .compact
+
+    if !overrides.contains(UITraitHorizontalSizeClass.self)
+      || overrides.horizontalSizeClass != desired {
+      hostingController.traitOverrides.horizontalSizeClass = desired
+    }
   }
 #endif
 

--- a/packages/react-native-bottom-tabs/package.json
+++ b/packages/react-native-bottom-tabs/package.json
@@ -45,7 +45,9 @@
   },
   "jest": {
     "preset": "react-native",
-    "modulePathIgnorePatterns": ["<rootDir>/lib/"]
+    "modulePathIgnorePatterns": [
+      "<rootDir>/lib/"
+    ]
   },
   "keywords": [
     "react-native",

--- a/packages/react-native-bottom-tabs/src/TabView.tsx
+++ b/packages/react-native-bottom-tabs/src/TabView.tsx
@@ -50,7 +50,9 @@ interface Props<Route extends BaseRoute> {
    * that varies depending on the platform:
    * Tab views using the sidebar adaptable style have an appearance
    * - iPadOS displays a top tab bar that can adapt into a sidebar.
-   * - iOS displays a bottom tab bar.
+   * - iOS displays a bottom tab bar. On iOS 27+ (built with Xcode 27+), large enough
+   *   screens such as an unfolded iPhone Duo display a sidebar instead, and the
+   *   bottom tab bar returns when the window shrinks.
    * - macOS and tvOS always show a sidebar.
    * - visionOS shows an ornament and also shows a sidebar for secondary tabs within a `TabSection`.
    */


### PR DESCRIPTION
## PR Description

Feature. `sidebarAdaptable` already turned the tab bar into a sidebar on iPadOS, macOS, tvOS and visionOS, but on iOS it always fell back to the bottom tab bar. This enables it on iOS too, for screens that are large enough — most notably an unfolded iPhone Duo.

iOS 27 shows the iPhone sidebar only when the tab bar controller's horizontal size class is regular, so the change is in two parts:

- **Opt into the placement.** When `sidebarAdaptable` is set, the tab view applies `defaultTabBarPlacement(.sidebar)` and sets `sidebar.preferredLayout = .tile` on iPhone, so the selected scene is laid out beside the sidebar instead of underneath it. The scene is measured within that content area, so React Native lays out against the visible width.
- **Derive the width class from the window.** `TabViewProvider` sets `traitOverrides.horizontalSizeClass` on the hosting controller from the actual window size: regular at ≥ 920pt wide with a regular vertical size class, compact otherwise. UIKit then switches between the sidebar and the bottom tab bar on its own as the window resizes.

The 920pt floor is deliberate. UIKit collapses the iPhone sidebar below roughly 905pt even in a regular width, and hides the tab bar at the same time, which leaves a blank strip. Forcing compact below the floor keeps the bottom tab bar there. Regular phones never reach that width in portrait, and landscape phones are excluded by their compact vertical size class, so existing apps are unaffected.

Everything is gated behind `#available(iOS 27.0, *)` and `compiler(>=6.4)`, so older runtimes and older Xcode versions are unchanged.

## How to test?

There is no iPhone Duo simulator yet, so the unfolded display is approximated with Xcode 27's Device Hub Resize Mode:

1. Build the example app with Xcode 27 and run it on an iOS 27 simulator.
2. Open an example that sets `sidebarAdaptable`, such as **Four Tabs** or **Six Tabs**. (**Three Tabs** deliberately does not set it and stays on bottom tabs.)
3. In Device Hub, enable **Resize mode** and widen the window past ~920pt. The bottom tab bar becomes a sidebar.
4. Shrink it back below the threshold. The bottom tab bar returns.

Verified at 402×874, 655×874 and 900×675 (bottom tabs) and at 1000×750 and 1280×874 (sidebar), resizing in both directions.

## Screenshots

| Six Tabs at 1280×874 | Six Tabs at 402×874 |
| --- | --- |
| Sidebar | Bottom tab bar |

<!-- Attach final_six_tabs_1280x874.png and final_six_tabs_402x874.png here. -->

## Notes

- Full iPhone Duo support cannot be finished until the Duo simulator ships. This PR is scoped to enabling `sidebarAdaptable` on large enough iOS screens.
- The tab bar height reported through `BottomTabBarHeightContext` is not updated while the sidebar is showing. Worth a follow-up if screens pad for the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
